### PR TITLE
Fixed length calculation fault on foreign characters

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -132,7 +132,8 @@ JsonSocket.prototype = {
     },
     _formatMessageData: function(message) {
         var messageData = JSON.stringify(message);
-        var data = messageData.length + '#' + messageData;
+		var length = Buffer.byteLength(messageData, 'utf8');       
+        var data = length + '#' + messageData;        
         return data;
     },
 


### PR DESCRIPTION
To properly calculate the byte length of a utf-8 string (required when dealing with non node peers), use Buffer.byteLength instead of string.length.
