### PR TITLE
Pass the error instead of the message when message.success === false

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -39,7 +39,7 @@ JsonSocket.sendSingleMessageAndReceive = function(port, host, message, callback)
             socket.on('message', function(message) {
                 socket.end();
                 if (message.success === false) {
-                    return callback(new Error(message.message));
+                    return callback(new Error(message.error));
                 }
                 callback(null, message)
             });


### PR DESCRIPTION
Without this, when there is an error, there is no explicit message in the stack trace.
