### PR TITLE
delegate socket 'close' event in order to handle any closure

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -151,7 +151,8 @@ JsonSocket.prototype = {
 var delegates = [
     'connect',
     'on',
-    'end'
+    'end',
+    'close'
 ];
 delegates.forEach(function(method) {
     JsonSocket.prototype[method] = function() {


### PR DESCRIPTION
As far as I can tell, the `end` event is only emitted if the closure was due to TCP `FIN` i.e. an intended closure.

A closure due to an error does not emit `end`, but both cases emit `close`. This patch just delegates that event as well.