### PR TITLE
Allow multiple requests to use the same packet through Buffers

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -65,6 +65,10 @@ JsonSocket.prototype = {
         if (state && this._flushInterval) {
             return;
         }
+        if (!state && this._flushInterval) {
+            clearInterval(this._flushInterval);
+            return;
+        }
         var lastCheckSize = 0;
         this._flushInterval = setInterval(function () {
             if (this.isClosed()) {

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -72,7 +72,7 @@ JsonSocket.prototype = {
         var start = Date.now(),
             that = this;
         setInterval(function () {
-            console.log((that.dataTreated / (Date.now() - start) / 1000) + ' Bytes/s');
+            console.log((that.dataTreated / ((Date.now() - start) / 1000)) + ' Bytes/s');
         }, 2000);
     },
     _handleData: function (data) {

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -1,9 +1,13 @@
 var net = require('net');
+const BUFFER_SIZE = 65535,
+    FLUSH_TIMEOUT = 5;
 
-var JsonSocket = function(socket) {
+var JsonSocket = function (socket) {
     this._socket = socket;
     this._contentLength = null;
-    this._buffer = '';
+    this._buffer = new Buffer(0);
+    this._writeBuffer = new Buffer(BUFFER_SIZE);
+    this._writeBufferOffset = 0;
     this._closed = false;
     socket.on('data', this._onData.bind(this));
     socket.on('close', this._onClose.bind(this));
@@ -11,32 +15,34 @@ var JsonSocket = function(socket) {
 };
 module.exports = JsonSocket;
 
-JsonSocket.sendSingleMessage = function(port, host, message, callback) {
-    callback = callback || function(){};
+JsonSocket.sendSingleMessage = function (port, host, message, callback) {
+    callback = callback || function () {
+    };
     var socket = new JsonSocket(new net.Socket());
     socket.connect(port, host);
-    socket.on('error', function(err) {
+    socket.on('error', function (err) {
         callback(err);
     });
-    socket.on('connect', function() {
+    socket.on('connect', function () {
         socket.sendEndMessage(message, callback);
     });
 };
 
-JsonSocket.sendSingleMessageAndReceive = function(port, host, message, callback) {
-    callback = callback || function(){};
+JsonSocket.sendSingleMessageAndReceive = function (port, host, message, callback) {
+    callback = callback || function () {
+    };
     var socket = new JsonSocket(new net.Socket());
     socket.connect(port, host);
-    socket.on('error', function(err) {
+    socket.on('error', function (err) {
         callback(err);
     });
-    socket.on('connect', function() {
-        socket.sendMessage(message, function(err) {
+    socket.on('connect', function () {
+        socket.sendMessage(message, function (err) {
             if (err) {
                 socket.end();
                 return callback(err);
             }
-            socket.on('message', function(message) {
+            socket.on('message', function (message) {
                 socket.end();
                 if (message.success === false) {
                     return callback(new Error(message.message));
@@ -49,80 +55,100 @@ JsonSocket.sendSingleMessageAndReceive = function(port, host, message, callback)
 
 JsonSocket.prototype = {
 
-    _onData: function(data) {
-        data = data.toString();
+    _onData: function (data) {
         try {
             this._handleData(data);
         } catch (e) {
             this.sendError(e);
         }
     },
-    _handleData: function(data) {
-        this._buffer += data;
+    _handleData: function (data) {
+        this._buffer = Buffer.concat([this._buffer, data], this._buffer.length + data.length);
         if (this._contentLength == null) {
             var i = this._buffer.indexOf('#');
             //Check if the buffer has a #, if not, the end of the buffer string might be in the middle of a content length string
             if (i !== -1) {
-                var rawContentLength = this._buffer.substring(0, i);
+                var rawContentLength = this._buffer.toString('ascii', 0, i);
                 this._contentLength = parseInt(rawContentLength);
                 if (isNaN(this._contentLength)) {
                     this._contentLength = null;
-                    this._buffer = '';
-                    var err = new Error('Invalid content length supplied ('+rawContentLength+') in: '+this._buffer);
+                    this._buffer = new Buffer(0);
+                    var err = new Error('Invalid content length supplied (' + rawContentLength + ') in: ' + this._buffer);
                     err.code = 'E_INVALID_CONTENT_LENGTH';
                     throw err;
                 }
-                this._buffer = this._buffer.substring(i+1);
+                this._buffer = this._buffer.slice(i + 1);
             }
         }
         if (this._contentLength != null) {
             if (this._buffer.length == this._contentLength) {
-                this._handleMessage(this._buffer);
+                this._handleMessage(this._buffer.toString('utf8'));
             } else if (this._buffer.length > this._contentLength) {
-                var message = this._buffer.substring(0, this._contentLength);
-                var rest = this._buffer.substring(this._contentLength);
+                var message = this._buffer.toString('utf8', 0, this._contentLength);
+                var rest = this._buffer.slice(this._contentLength);
                 this._handleMessage(message);
                 this._onData(rest);
             }
         }
     },
-    _handleMessage: function(data) {
+    _handleMessage: function (data) {
         this._contentLength = null;
-        this._buffer = '';
+        this._buffer = new Buffer(0);
         var message;
         try {
             message = JSON.parse(data);
         } catch (e) {
-            var err = new Error('Could not parse JSON: '+e.message+'\nRequest data: '+data);
+            var err = new Error('Could not parse JSON: ' + e.message + '\nRequest data: ' + data);
             err.code = 'E_INVALID_JSON';
             throw err;
         }
         message = message || {};
         this._socket.emit('message', message);
     },
-    
-    sendError: function(err) {
+
+    sendError: function (err) {
         this.sendMessage(this._formatError(err));
     },
-    sendEndError: function(err) {
+    sendEndError: function (err) {
         this.sendEndMessage(this._formatError(err));
     },
-    _formatError: function(err) {
+    _formatError: function (err) {
         return {success: false, error: err.toString()};
     },
 
-    sendMessage: function(message, callback) {
+    _flushBuffer: function (callback) {
+        this._socket.write(this._writeBuffer.slice(0, this._writeBufferOffset), 'utf-8', callback);
+        this._writeBuffer = new Buffer(BUFFER_SIZE);
+        this._writeBufferOffset = 0;
+    },
+
+    sendMessage: function (message, callback) {
+        clearTimeout(this._flushTimer);
         if (this._closed) {
             if (callback) {
                 callback(new Error('The socket is closed.'));
             }
             return;
         }
-        this._socket.write(this._formatMessageData(message), 'utf-8', callback);
-    },
-    sendEndMessage: function(message, callback) {
+        var formattedMsg = this._formatMessageData(message);
+        if (formattedMsg.length + this._writeBufferOffset > BUFFER_SIZE) {
+            this._flushBuffer();
+        }
+        this._writeBuffer.write(formattedMsg, this._writeBufferOffset);
+        this._writeBufferOffset += Buffer.byteLength(formattedMsg, 'utf8');
+        if (callback) {
+            callback();
+        }
         var that = this;
-        this.sendMessage(message, function(err) {
+        this._flushTimer = setTimeout(function () {
+            that._flushBuffer();
+        }, FLUSH_TIMEOUT);
+    },
+    sendEndMessage: function (message, callback) {
+        var that = this;
+        this.sendMessage(message);
+        clearTimeout(this._flushTimer);
+        this._flushBuffer(function (err) {
             that.end();
             if (callback) {
                 if (err) return callback(err);
@@ -130,19 +156,19 @@ JsonSocket.prototype = {
             }
         });
     },
-    _formatMessageData: function(message) {
+    _formatMessageData: function (message) {
         var messageData = JSON.stringify(message);
-        var data = messageData.length + '#' + messageData;
+        var data = Buffer.byteLength(messageData) + '#' + messageData;
         return data;
     },
 
-    _onClose: function() {
+    _onClose: function () {
         this._closed = true;
     },
-    _onError: function() {
+    _onError: function () {
         this._closed = true;
     },
-    isClosed: function() {
+    isClosed: function () {
         return this._closed;
     }
 
@@ -153,8 +179,8 @@ var delegates = [
     'on',
     'end'
 ];
-delegates.forEach(function(method) {
-    JsonSocket.prototype[method] = function() {
+delegates.forEach(function (method) {
+    JsonSocket.prototype[method] = function () {
         this._socket[method].apply(this._socket, arguments);
         return this
     }

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -6,6 +6,8 @@ var JsonSocket = function (socket) {
     this._socket = socket;
     this._waitMessageSize = 0;
     this._closed = false;
+    this.dataTreated = 0;
+    this._statistics = false;
     socket.on('data', this._onData.bind(this));
     socket.on('close', this._onClose.bind(this));
     socket.on('err', this._onError.bind(this));
@@ -53,11 +55,22 @@ JsonSocket.sendSingleMessageAndReceive = function (port, host, message, callback
 JsonSocket.prototype = {
 
     _onData: function (data) {
+        if (this._statistics) {
+            this.dataTreated += data.length;
+        }
         try {
             this._handleData(data);
         } catch (e) {
             this.sendError(e);
         }
+    },
+    statistics: function () {
+        this._statistics = true;
+        var start = Date.now(),
+            that = this;
+        setInterval(function () {
+            console.log((that.dataTreated / (Date.now() - start) / 1000) + ' Bytes/s');
+        }, 2000);
     },
     _handleData: function (data) {
         if (this._waitMessageSize === 0) {

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -1,5 +1,5 @@
 var net = require('net');
-const BUFFER_SIZE = 65535,
+const BUFFER_SIZE = 65536,
     FLUSH_TIMEOUT = 5;
 
 var JsonSocket = function (socket) {
@@ -9,6 +9,8 @@ var JsonSocket = function (socket) {
     this.dataTreated = 0;
     this._statistics = false;
     this._jsonBuffer = '';
+    this._bufferCursor = 0;
+    this._jsonBufferLength = 0;
     socket.on('data', this._onData.bind(this));
     socket.on('connect', this._onConnect.bind(this));
     socket.on('close', this._onClose.bind(this));
@@ -76,7 +78,7 @@ JsonSocket.prototype = {
         var start = Date.now(),
             that = this;
         setInterval(function () {
-            console.log((that.dataTreated / ((Date.now() - start) / 1000)) + ' MBytes/s');
+            console.log((that.dataTreated / 1000000 / ((Date.now() - start) / 1000)) + ' MBytes/s');
         }, 2000);
     },
     _handleData: function (data) {
@@ -87,6 +89,7 @@ JsonSocket.prototype = {
         if (this._waitMessageSize === 0) {
 
             if (data.length < 4) {
+                //console.log('missing some');
                 this._messageSizeBuffer = data;
                 return;
             }
@@ -95,41 +98,58 @@ JsonSocket.prototype = {
 
             if (data.length - 4 === messageSize) {
                 if (this._jsonBuffer != '') {
+                    this._jsonBufferLength++;
+                    this._jsonBuffer += data.toString('utf8', 4, messageSize + 4) + ',';
                     this._handleMultipleMessages();
+                    return;
                 }
                 this._handleMessage(data.slice(4));
             } else if (data.length - 4 > messageSize) {
+                this._jsonBufferLength++;
                 this._jsonBuffer += data.toString('utf8', 4, messageSize + 4) + ',';
-                //this._handleMessage(data.slice(4, messageSize + 4));
+                //if (this._jsonBufferLength > 20) {
                 this._handleData(data.slice(messageSize + 4));
+                //this._handleMultipleMessages();
+                //}
+                //this._handleMessage(data.slice(4, messageSize + 4));
             } else {
                 if (this._jsonBuffer != '') {
                     this._handleMultipleMessages();
                 }
                 this._buffer = data.slice(4);
                 this._waitMessageSize = messageSize;
+                //console.log('wait for ', messageSize, data.toString(), this._buffer.length);
             }
         } else {
             this._buffer = Buffer.concat([this._buffer, data]);
-            if (this._buffer.length >= this._waitMessageSize) {
+            var bufferLength = this._buffer.length;
+            if (bufferLength >= this._waitMessageSize) {
                 this._handleMessage(this._buffer.slice(0, this._waitMessageSize));
+                if (bufferLength == this._waitMessageSize) {
+                    //console.log('ici aussi ?');
+                    this._waitMessageSize = 0;
+                    return;
+                }
             }
-            if (this._buffer.length > this._waitMessageSize) {
-                var savedMessSize = this._waitMessageSize;
+            if (bufferLength > this._waitMessageSize) {
+                //console.log('arrivé ?', bufferLength, this._waitMessageSize);
+                var retainedSize = this._waitMessageSize;
                 this._waitMessageSize = 0;
-                this._handleData(this._buffer.slice(savedMessSize));
-            } else if (this._buffer.length === this._waitMessageSize) {
-                this._waitMessageSize = 0;
+                this._handleData(this._buffer.slice(retainedSize));
             }
         }
     },
     _handleMultipleMessages: function () {
         var messages = JSON.parse('[' + this._jsonBuffer.substring(0, this._jsonBuffer.length - 1) + ']');
         this._jsonBuffer = '';
+        this._jsonBufferLength = 0;
         messages.forEach(this._emitMessage.bind(this));
     },
     _emitMessage: function (message) {
-        this._socket.emit('message', message);
+        var that = this;
+        process.nextTick(function () {
+            that._socket.emit('message', message);
+        });
     },
     _handleMessage: function (data) {
         var message;
@@ -161,6 +181,35 @@ JsonSocket.prototype = {
         }
         this._socket.write(this._formatMessageData(message), callback);
     },
+    nextCall:false,
+    sendDeferred: function (message, flush) {
+        if (this.nextCall) {
+            //console.log('second call', message, this._messagesBuffer.length, this._bufferCursor);
+        }
+        if (message.length > BUFFER_SIZE) {
+            throw new Error('Message to big to enter in the buffer');
+        }
+        if (!this._messagesBuffer) {
+            this._messagesBuffer = new Buffer(BUFFER_SIZE);
+        }
+        var writeToBuffer = this._objectToBuffer(message, this._messagesBuffer, this._bufferCursor).size;
+        if (writeToBuffer === false || flush) {
+            if (flush && writeToBuffer) {
+                this._bufferCursor += writeToBuffer;
+            }
+            this._socket.write(this._messagesBuffer.slice(0, this._bufferCursor));
+            this._messagesBuffer = new Buffer(BUFFER_SIZE);
+            this._bufferCursor = 0;
+            //console.log(writeToBuffer, flush);
+            if (writeToBuffer === false) {
+                this.sendDeferred(message, flush);
+            }
+        } else {
+            this._bufferCursor += writeToBuffer;
+        }
+
+        this.nextCall = false;
+    },
     sendEndMessage: function (message, callback) {
         var that = this;
         this.sendMessage(message, function (err) {
@@ -171,14 +220,30 @@ JsonSocket.prototype = {
             }
         });
     },
-    _formatMessageData: function (message) {
+    _objectToBuffer: function (message, buffer, offset) {
         var messageData = JSON.stringify(message),
             messageSize = Buffer.byteLength(messageData, 'utf8');
-
-        var data = new Buffer(messageSize + 4);
-        data.writeUInt32LE(messageSize, 0);
-        data.write(messageData, 4, messageSize);
-        return data;
+        if (!buffer) {
+            buffer = new Buffer(messageSize + 4);
+        }
+        if (!offset) {
+            offset = 0;
+        }
+        if (messageSize + 4 + offset > buffer.length) {
+            return {
+                buffer: buffer,
+                size: false
+            };
+        }
+        buffer.writeUInt32LE(messageSize, offset);
+        buffer.write(messageData, offset + 4, messageSize);
+        return {
+            buffer: buffer,
+            size: messageSize + 4
+        };
+    },
+    _formatMessageData: function (message) {
+        return this._objectToBuffer(message).buffer;
     },
 
     _onClose: function () {

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -11,10 +11,22 @@ var JsonSocket = function (socket) {
     this._jsonBuffer = '';
     this._bufferCursor = 0;
     this._jsonBufferLength = 0;
+    this._lastFlush = Date.now();
     socket.on('data', this._onData.bind(this));
     socket.on('connect', this._onConnect.bind(this));
     socket.on('close', this._onClose.bind(this));
     socket.on('err', this._onError.bind(this));
+    var lastCheckSize = 0,
+        that = this;
+    setInterval(function () {
+        if (that.isClosed()) {
+            return;
+        }
+        if (Date.now() - that._lastFlush > 100 && lastCheckSize > 0 && that._bufferCursor >= lastCheckSize) {
+            that.sendDeferred(undefined, true);
+        }
+        lastCheckSize = that._bufferCursor;
+    }, 30);
 };
 module.exports = JsonSocket;
 
@@ -89,7 +101,6 @@ JsonSocket.prototype = {
         if (this._waitMessageSize === 0) {
 
             if (data.length < 4) {
-                //console.log('missing some');
                 this._messageSizeBuffer = data;
                 return;
             }
@@ -181,34 +192,30 @@ JsonSocket.prototype = {
         }
         this._socket.write(this._formatMessageData(message), callback);
     },
-    nextCall:false,
     sendDeferred: function (message, flush) {
-        if (this.nextCall) {
-            //console.log('second call', message, this._messagesBuffer.length, this._bufferCursor);
-        }
-        if (message.length > BUFFER_SIZE) {
-            throw new Error('Message to big to enter in the buffer');
-        }
         if (!this._messagesBuffer) {
             this._messagesBuffer = new Buffer(BUFFER_SIZE);
         }
-        var writeToBuffer = this._objectToBuffer(message, this._messagesBuffer, this._bufferCursor).size;
+        var writeToBuffer;
+        if (message != void 0) {
+            writeToBuffer = this._objectToBuffer(message, this._messagesBuffer, this._bufferCursor).size;
+        } else {
+            writeToBuffer = 0;
+        }
         if (writeToBuffer === false || flush) {
             if (flush && writeToBuffer) {
                 this._bufferCursor += writeToBuffer;
             }
             this._socket.write(this._messagesBuffer.slice(0, this._bufferCursor));
+            this._lastFlush = Date.now();
             this._messagesBuffer = new Buffer(BUFFER_SIZE);
             this._bufferCursor = 0;
-            //console.log(writeToBuffer, flush);
             if (writeToBuffer === false) {
                 this.sendDeferred(message, flush);
             }
         } else {
             this._bufferCursor += writeToBuffer;
         }
-
-        this.nextCall = false;
     },
     sendEndMessage: function (message, callback) {
         var that = this;
@@ -225,6 +232,8 @@ JsonSocket.prototype = {
             messageSize = Buffer.byteLength(messageData, 'utf8');
         if (!buffer) {
             buffer = new Buffer(messageSize + 4);
+        } else if (messageSize > BUFFER_SIZE) {
+            throw new Error('Message to big to enter in the buffer')
         }
         if (!offset) {
             offset = 0;

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -76,7 +76,7 @@ JsonSocket.prototype = {
         var start = Date.now(),
             that = this;
         setInterval(function () {
-            console.log((that.dataTreated / ((Date.now() - start) / 1000)) + ' Bytes/s');
+            console.log((that.dataTreated / ((Date.now() - start) / 1000)) + ' MBytes/s');
         }, 2000);
     },
     _handleData: function (data) {

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -118,7 +118,7 @@ JsonSocket.prototype = {
 
     _flushBuffer: function (callback) {
         this._socket.write(this._writeBuffer.slice(0, this._writeBufferOffset), 'utf-8', callback);
-        this._writeBuffer = new Buffer(BUFFER_SIZE);
+        //this._writeBuffer = new Buffer(BUFFER_SIZE);
         this._writeBufferOffset = 0;
     },
 

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -16,17 +16,6 @@ var JsonSocket = function (socket) {
     socket.on('connect', this._onConnect.bind(this));
     socket.on('close', this._onClose.bind(this));
     socket.on('err', this._onError.bind(this));
-    var lastCheckSize = 0,
-        that = this;
-    setInterval(function () {
-        if (that.isClosed()) {
-            return;
-        }
-        if (Date.now() - that._lastFlush > 100 && lastCheckSize > 0 && that._bufferCursor >= lastCheckSize) {
-            that.sendDeferred(undefined, true);
-        }
-        lastCheckSize = that._bufferCursor;
-    }, 30);
 };
 module.exports = JsonSocket;
 
@@ -69,6 +58,24 @@ JsonSocket.sendSingleMessageAndReceive = function (port, host, message, callback
 };
 
 JsonSocket.prototype = {
+    autoFlush: function (state) {
+        if (state == void 0) {
+            state = true;
+        }
+        if (state && this._flushInterval) {
+            return;
+        }
+        var lastCheckSize = 0;
+        this._flushInterval = setInterval(function () {
+            if (this.isClosed()) {
+                return;
+            }
+            if (Date.now() - this._lastFlush > 100 && lastCheckSize > 0 && this._bufferCursor >= lastCheckSize) {
+                this.sendDeferred(undefined, true);
+            }
+            lastCheckSize = this._bufferCursor;
+        }.bind(this), 30);
+    },
     _onConnect: function () {
         this._closed = false;
     },

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -10,6 +10,7 @@ var JsonSocket = function (socket) {
     this._statistics = false;
     this._jsonBuffer = '';
     socket.on('data', this._onData.bind(this));
+    socket.on('connect', this._onConnect.bind(this));
     socket.on('close', this._onClose.bind(this));
     socket.on('err', this._onError.bind(this));
 };
@@ -54,7 +55,9 @@ JsonSocket.sendSingleMessageAndReceive = function (port, host, message, callback
 };
 
 JsonSocket.prototype = {
-
+    _onConnect: function () {
+        this._closed = false;
+    },
     _onData: function (data) {
         if (this._statistics) {
             this.dataTreated += data.length;

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -4,10 +4,7 @@ const BUFFER_SIZE = 65535,
 
 var JsonSocket = function (socket) {
     this._socket = socket;
-    this._contentLength = null;
-    this._buffer = new Buffer(0);
-    this._writeBuffer = new Buffer(BUFFER_SIZE);
-    this._writeBufferOffset = 0;
+    this._waitMessageSize = 0;
     this._closed = false;
     socket.on('data', this._onData.bind(this));
     socket.on('close', this._onClose.bind(this));
@@ -63,40 +60,36 @@ JsonSocket.prototype = {
         }
     },
     _handleData: function (data) {
-        this._buffer = Buffer.concat([this._buffer, data], this._buffer.length + data.length);
-        if (this._contentLength == null) {
-            var i = this._buffer.indexOf('#');
-            //Check if the buffer has a #, if not, the end of the buffer string might be in the middle of a content length string
-            if (i !== -1) {
-                var rawContentLength = this._buffer.toString('ascii', 0, i);
-                this._contentLength = parseInt(rawContentLength);
-                if (isNaN(this._contentLength)) {
-                    this._contentLength = null;
-                    this._buffer = new Buffer(0);
-                    var err = new Error('Invalid content length supplied (' + rawContentLength + ') in: ' + this._buffer);
-                    err.code = 'E_INVALID_CONTENT_LENGTH';
-                    throw err;
-                }
-                this._buffer = this._buffer.slice(i + 1);
+        if (this._waitMessageSize === 0) {
+            var messageSize = data.readUInt32LE();
+
+            if (data.length - 4 === messageSize) {
+                this._handleMessage(data.slice(4));
+            } else if (data.length - 4 > messageSize) {
+                this._handleMessage(data.slice(4, messageSize + 4));
+                this._handleData(data.slice(messageSize + 4));
+            } else {
+                this._buffer = data.slice(4);
+                this._waitMessageSize = messageSize;
             }
-        }
-        if (this._contentLength != null) {
-            if (this._buffer.length == this._contentLength) {
-                this._handleMessage(this._buffer.toString('utf8'));
-            } else if (this._buffer.length > this._contentLength) {
-                var message = this._buffer.toString('utf8', 0, this._contentLength);
-                var rest = this._buffer.slice(this._contentLength);
-                this._handleMessage(message);
-                this._onData(rest);
+        } else {
+            this._buffer = Buffer.concat([this._buffer, data]);
+            if (this._buffer.length >= this._waitMessageSize) {
+                this._handleMessage(this._buffer.slice(0, this._waitMessageSize));
+            }
+            if (this._buffer.length > this._waitMessageSize) {
+                var savedMessSize = this._waitMessageSize;
+                this._waitMessageSize = 0;
+                this._handleData(this._buffer.slice(savedMessSize));
+            } else if (this._buffer.length === this._waitMessageSize) {
+                this._waitMessageSize = 0;
             }
         }
     },
     _handleMessage: function (data) {
-        this._contentLength = null;
-        this._buffer = new Buffer(0);
         var message;
         try {
-            message = JSON.parse(data);
+            message = JSON.parse(data.toString());
         } catch (e) {
             var err = new Error('Could not parse JSON: ' + e.message + '\nRequest data: ' + data);
             err.code = 'E_INVALID_JSON';
@@ -115,40 +108,18 @@ JsonSocket.prototype = {
     _formatError: function (err) {
         return {success: false, error: err.toString()};
     },
-
-    _flushBuffer: function (callback) {
-        this._socket.write(this._writeBuffer.slice(0, this._writeBufferOffset), 'utf-8', callback);
-        //this._writeBuffer = new Buffer(BUFFER_SIZE);
-        this._writeBufferOffset = 0;
-    },
-
     sendMessage: function (message, callback) {
-        clearTimeout(this._flushTimer);
         if (this._closed) {
             if (callback) {
                 callback(new Error('The socket is closed.'));
             }
             return;
         }
-        var formattedMsg = this._formatMessageData(message);
-        if (formattedMsg.length + this._writeBufferOffset > BUFFER_SIZE) {
-            this._flushBuffer();
-        }
-        this._writeBuffer.write(formattedMsg, this._writeBufferOffset);
-        this._writeBufferOffset += Buffer.byteLength(formattedMsg, 'utf8');
-        if (callback) {
-            callback();
-        }
-        var that = this;
-        this._flushTimer = setTimeout(function () {
-            that._flushBuffer();
-        }, FLUSH_TIMEOUT);
+        this._socket.write(this._formatMessageData(message), callback);
     },
     sendEndMessage: function (message, callback) {
         var that = this;
-        this.sendMessage(message);
-        clearTimeout(this._flushTimer);
-        this._flushBuffer(function (err) {
+        this.sendMessage(message, function (err) {
             that.end();
             if (callback) {
                 if (err) return callback(err);
@@ -157,8 +128,12 @@ JsonSocket.prototype = {
         });
     },
     _formatMessageData: function (message) {
-        var messageData = JSON.stringify(message);
-        var data = Buffer.byteLength(messageData) + '#' + messageData;
+        var messageData = JSON.stringify(message),
+            messageSize = Buffer.byteLength(messageData, 'utf8');
+
+        var data = new Buffer(messageSize + 4);
+        data.writeUInt32LE(messageSize, 0);
+        data.write(messageData, 4, messageSize);
         return data;
     },
 

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -61,6 +61,9 @@ JsonSocket.prototype = {
         try {
             this._handleData(data);
         } catch (e) {
+            console.log(e);
+            console.log(e.stack);
+            process.exit();
             this.sendError(e);
         }
     },
@@ -73,7 +76,17 @@ JsonSocket.prototype = {
         }, 2000);
     },
     _handleData: function (data) {
+        if (this._messageSizeBuffer) {
+            data = Buffer.concat([this._messageSizeBuffer, data]);
+            this._messageSizeBuffer = null;
+        }
         if (this._waitMessageSize === 0) {
+
+            if (data.length < 4) {
+                this._messageSizeBuffer = data;
+                return;
+            }
+
             var messageSize = data.readUInt32LE();
 
             if (data.length - 4 === messageSize) {

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -8,6 +8,7 @@ var JsonSocket = function (socket) {
     this._closed = false;
     this.dataTreated = 0;
     this._statistics = false;
+    this._jsonBuffer = '';
     socket.on('data', this._onData.bind(this));
     socket.on('close', this._onClose.bind(this));
     socket.on('err', this._onError.bind(this));
@@ -90,11 +91,18 @@ JsonSocket.prototype = {
             var messageSize = data.readUInt32LE();
 
             if (data.length - 4 === messageSize) {
+                if (this._jsonBuffer != '') {
+                    this._handleMultipleMessages();
+                }
                 this._handleMessage(data.slice(4));
             } else if (data.length - 4 > messageSize) {
-                this._handleMessage(data.slice(4, messageSize + 4));
+                this._jsonBuffer += data.toString('utf8', 4, messageSize + 4) + ',';
+                //this._handleMessage(data.slice(4, messageSize + 4));
                 this._handleData(data.slice(messageSize + 4));
             } else {
+                if (this._jsonBuffer != '') {
+                    this._handleMultipleMessages();
+                }
                 this._buffer = data.slice(4);
                 this._waitMessageSize = messageSize;
             }
@@ -112,6 +120,14 @@ JsonSocket.prototype = {
             }
         }
     },
+    _handleMultipleMessages: function () {
+        var messages = JSON.parse('[' + this._jsonBuffer.substring(0, this._jsonBuffer.length - 1) + ']');
+        this._jsonBuffer = '';
+        messages.forEach(this._emitMessage.bind(this));
+    },
+    _emitMessage: function (message) {
+        this._socket.emit('message', message);
+    },
     _handleMessage: function (data) {
         var message;
         try {
@@ -122,9 +138,8 @@ JsonSocket.prototype = {
             throw err;
         }
         message = message || {};
-        this._socket.emit('message', message);
+        this._emitMessage(message);
     },
-
     sendError: function (err) {
         this.sendMessage(this._formatError(err));
     },

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -131,15 +131,6 @@ describe('JsonSocket connection', function () {
             if (err) return callback(err);
             async.parallel([
                 function (callback) {
-                    async.forEach(helpers.range(1, 9999), function (i, callback) {
-                        clientSocket.sendDeferred({number: i});
-                        if (i === 9999) {
-                            clientSocket.sendDeferred({number: 10000}, true);
-                        }
-                        callback();
-                    }, callback);
-                },
-                function (callback) {
                     serverSocket.statistics();
                     var lastNumber = 0;
                     serverSocket.on('message', function () {
@@ -148,6 +139,43 @@ describe('JsonSocket connection', function () {
                             callback();
                         }
                     });
+                },
+                function (callback) {
+                    async.forEach(helpers.range(1, 9999), function (i, callback) {
+                        clientSocket.sendDeferred({number: i});
+                        if (i === 9999) {
+                            clientSocket.sendDeferred({number: 10000}, true);
+                        }
+                        callback();
+                    }, callback);
+                }
+            ], function (err) {
+                if (err) return callback(err);
+                helpers.closeServer(server, callback);
+            });
+        });
+    });
+
+    it('send bulk messages through deferred with auto flush', function (callback) {
+        console.log('ici');
+        helpers.createServerAndClient(function (err, server, clientSocket, serverSocket) {
+            if (err) return callback(err);
+            async.parallel([
+                function (callback) {
+                    serverSocket.statistics();
+                    var lastNumber = 0;
+                    serverSocket.on('message', function (message) {
+                        lastNumber++;
+                        if (lastNumber == 10) {
+                            callback();
+                        }
+                    });
+                },
+                function (callback) {
+                    async.forEach(helpers.range(1, 10), function (i, callback) {
+                        clientSocket.sendDeferred({number: i});
+                        callback();
+                    }, callback);
                 }
             ], function (err) {
                 if (err) return callback(err);

--- a/test/connection.test.js
+++ b/test/connection.test.js
@@ -157,7 +157,6 @@ describe('JsonSocket connection', function () {
     });
 
     it('send bulk messages through deferred with auto flush', function (callback) {
-        console.log('ici');
         helpers.createServerAndClient(function (err, server, clientSocket, serverSocket) {
             if (err) return callback(err);
             async.parallel([
@@ -172,6 +171,7 @@ describe('JsonSocket connection', function () {
                     });
                 },
                 function (callback) {
+                    clientSocket.autoFlush();
                     async.forEach(helpers.range(1, 10), function (i, callback) {
                         clientSocket.sendDeferred({number: i});
                         callback();

--- a/test/message-parsing.test.js
+++ b/test/message-parsing.test.js
@@ -2,98 +2,105 @@ var assert = require('assert'),
     net = require('net'),
     JsonSocket = require('../lib/json-socket');
 
-describe('JsonSocket message parsing', function() {
+describe('JsonSocket message parsing', function () {
 
     var socket = new JsonSocket(new net.Socket());
     var messages = [];
-    socket.on('message', function(message) {
+    socket.on('message', function (message) {
         messages.push(message);
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
         messages = [];
-        socket._contentLength = null;
-        socket._buffer = new Buffer(0);
     });
 
-    it('should parse JSON strings', function() {
-        socket._handleData(new Buffer('13#"Hello there"'));
+    it('should parse JSON strings', function () {
+        socket._handleData(socket._formatMessageData("Hello there"));
         assert.equal(messages.length, 1);
         assert.equal(messages[0], 'Hello there');
-        assert.equal(socket._buffer, '');
     });
 
-    it('should parse JSON numbers', function() {
-        socket._handleData(new Buffer('5#12.34'));
+    it('should parse JSON numbers', function () {
+        socket._handleData(socket._formatMessageData('12.34'));
         assert.equal(messages.length, 1);
         assert.equal(messages[0], 12.34);
-        assert.equal(socket._buffer, '');
     });
 
-    it('should parse JSON bools', function() {
-        socket._handleData(new Buffer('4#true'));
+    it('should parse JSON bools', function () {
+        socket._handleData(socket._formatMessageData(true));
         assert.equal(messages.length, 1);
         assert.equal(messages[0], true);
-        assert.equal(socket._buffer, '');
     });
 
-    it('should parse JSON objects', function() {
-        socket._handleData(new Buffer('17#{"a":"yes","b":9}'));
+    it('should parse JSON objects', function () {
+        socket._handleData(socket._formatMessageData({"a": "yes", "b": 9}));
         assert.equal(messages.length, 1);
         assert.deepEqual(messages[0], {a: 'yes', b: 9});
-        assert.equal(socket._buffer, '');
     });
 
-    it('should parse JSON arrays', function() {
-        socket._handleData(new Buffer('9#["yes",9]'));
+    it('should parse JSON arrays', function () {
+        socket._handleData(socket._formatMessageData(["yes", 9]));
         assert.equal(messages.length, 1);
         assert.deepEqual(messages[0], ['yes', 9]);
-        assert.equal(socket._buffer, '');
     });
 
-    it('should parse multiple messages in one packet', function() {
-        socket._handleData(new Buffer('5#"hey"4#true'));
+    it('should parse multiple messages in one packet', function () {
+        socket._handleData(Buffer.concat([socket._formatMessageData("hey"), socket._formatMessageData(true)]));
         assert.equal(messages.length, 2);
         assert.equal(messages[0], 'hey');
         assert.equal(messages[1], true);
-        assert.equal(socket._buffer, '');
     });
 
-    it('should parse chunked messages', function() {
-        socket._handleData(new Buffer('13#"Hel'));
-        socket._handleData(new Buffer('lo there"'));
+    it('should parse chunked messages', function () {
+        var msgSize = Buffer.byteLength('"Hello there"');
+        var b = new Buffer(4 + Buffer.byteLength('"Hell'));
+        b.writeUInt32LE(msgSize);
+        b.write('"Hell', 4);
+        var c = new Buffer('o there"');
+
+        socket._handleData(b);
+        socket._handleData(c);
         assert.equal(messages.length, 1);
         assert.equal(messages[0], 'Hello there');
-        assert.equal(socket._buffer, '');
     });
 
-    it('should parse chunked and multiple messages', function() {
-        socket._handleData(new Buffer('13#"Hel'));
-        socket._handleData(new Buffer('lo there"4#true'));
+    it('should parse chunked and multiple messages', function () {
+        var msgSize = Buffer.byteLength('"Hello there"');
+        var b = new Buffer(4 + Buffer.byteLength('"Hell'));
+        b.writeUInt32LE(msgSize);
+        b.write('"Hell', 4);
+        var c = new Buffer('o there"');
+
+        //console.log('par', b.toString());
+        socket._handleData(b);
+        //console.log('par', Buffer.concat([c, socket._formatMessageData(true)]).toString());
+        socket._handleData(Buffer.concat([c, socket._formatMessageData(true)]));
         assert.equal(messages.length, 2);
         assert.equal(messages[0], 'Hello there');
         assert.equal(messages[1], true);
-        assert.equal(socket._buffer, '');
     });
 
-    it('should fail to parse invalid JSON', function() {
+    it('should fail to parse invalid JSON', function () {
+        var msgSize = Buffer.byteLength('"Hel');
+        var b = new Buffer(4 + msgSize);
+        b.writeUInt32LE(msgSize);
+        b.write('"Hel', 4);
         try {
-            socket._handleData(new Buffer('4#"Hel'));
+            socket._handleData(b);
         } catch (err) {
             assert.equal(err.code, 'E_INVALID_JSON');
         }
         assert.equal(messages.length, 0);
-        assert.equal(socket._buffer, '');
     });
 
-    it('should not accept invalid content length', function() {
-        try {
-            socket._handleData(new Buffer('wtf#"Hello"'));
-        } catch (err) {
-            assert.equal(err.code, 'E_INVALID_CONTENT_LENGTH');
-        }
-        assert.equal(messages.length, 0);
-        assert.equal(socket._buffer, '');
-    });
+    //it('should not accept invalid content length', function () {
+    //    try {
+    //        socket._handleData(socket._formatMessageData('wtf#"Hello"'));
+    //    } catch (err) {
+    //        assert.equal(err.code, 'E_INVALID_CONTENT_LENGTH');
+    //    }
+    //    assert.equal(messages.length, 0);
+    //    assert.equal(socket._buffer, '');
+    //});
 
 });

--- a/test/message-parsing.test.js
+++ b/test/message-parsing.test.js
@@ -9,50 +9,50 @@ describe('JsonSocket message parsing', function() {
     socket.on('message', function(message) {
         messages.push(message);
     });
-    
+
     beforeEach(function() {
         messages = [];
         socket._contentLength = null;
-        socket._buffer = '';
+        socket._buffer = new Buffer(0);
     });
 
     it('should parse JSON strings', function() {
-        socket._handleData('13#"Hello there"');
+        socket._handleData(new Buffer('13#"Hello there"'));
         assert.equal(messages.length, 1);
         assert.equal(messages[0], 'Hello there');
         assert.equal(socket._buffer, '');
     });
 
     it('should parse JSON numbers', function() {
-        socket._handleData('5#12.34');
+        socket._handleData(new Buffer('5#12.34'));
         assert.equal(messages.length, 1);
         assert.equal(messages[0], 12.34);
         assert.equal(socket._buffer, '');
     });
 
     it('should parse JSON bools', function() {
-        socket._handleData('4#true');
+        socket._handleData(new Buffer('4#true'));
         assert.equal(messages.length, 1);
         assert.equal(messages[0], true);
         assert.equal(socket._buffer, '');
     });
 
     it('should parse JSON objects', function() {
-        socket._handleData('17#{"a":"yes","b":9}');
+        socket._handleData(new Buffer('17#{"a":"yes","b":9}'));
         assert.equal(messages.length, 1);
         assert.deepEqual(messages[0], {a: 'yes', b: 9});
         assert.equal(socket._buffer, '');
     });
 
     it('should parse JSON arrays', function() {
-        socket._handleData('9#["yes",9]');
+        socket._handleData(new Buffer('9#["yes",9]'));
         assert.equal(messages.length, 1);
         assert.deepEqual(messages[0], ['yes', 9]);
         assert.equal(socket._buffer, '');
     });
 
     it('should parse multiple messages in one packet', function() {
-        socket._handleData('5#"hey"4#true');
+        socket._handleData(new Buffer('5#"hey"4#true'));
         assert.equal(messages.length, 2);
         assert.equal(messages[0], 'hey');
         assert.equal(messages[1], true);
@@ -60,16 +60,16 @@ describe('JsonSocket message parsing', function() {
     });
 
     it('should parse chunked messages', function() {
-        socket._handleData('13#"Hel');
-        socket._handleData('lo there"');
+        socket._handleData(new Buffer('13#"Hel'));
+        socket._handleData(new Buffer('lo there"'));
         assert.equal(messages.length, 1);
         assert.equal(messages[0], 'Hello there');
         assert.equal(socket._buffer, '');
     });
 
     it('should parse chunked and multiple messages', function() {
-        socket._handleData('13#"Hel');
-        socket._handleData('lo there"4#true');
+        socket._handleData(new Buffer('13#"Hel'));
+        socket._handleData(new Buffer('lo there"4#true'));
         assert.equal(messages.length, 2);
         assert.equal(messages[0], 'Hello there');
         assert.equal(messages[1], true);
@@ -78,7 +78,7 @@ describe('JsonSocket message parsing', function() {
 
     it('should fail to parse invalid JSON', function() {
         try {
-            socket._handleData('4#"Hel');
+            socket._handleData(new Buffer('4#"Hel'));
         } catch (err) {
             assert.equal(err.code, 'E_INVALID_JSON');
         }
@@ -88,12 +88,12 @@ describe('JsonSocket message parsing', function() {
 
     it('should not accept invalid content length', function() {
         try {
-            socket._handleData('wtf#"Hello"');
+            socket._handleData(new Buffer('wtf#"Hello"'));
         } catch (err) {
             assert.equal(err.code, 'E_INVALID_CONTENT_LENGTH');
         }
         assert.equal(messages.length, 0);
         assert.equal(socket._buffer, '');
     });
-    
+
 });

--- a/test/message-parsing.test.js
+++ b/test/message-parsing.test.js
@@ -14,44 +14,62 @@ describe('JsonSocket message parsing', function () {
         messages = [];
     });
 
-    it('should parse JSON strings', function () {
+    it('should parse JSON strings', function (cb) {
         socket._handleData(socket._formatMessageData("Hello there"));
-        assert.equal(messages.length, 1);
-        assert.equal(messages[0], 'Hello there');
+        process.nextTick(function () {
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0], 'Hello there');
+            cb();
+        });
     });
 
-    it('should parse JSON numbers', function () {
+    it('should parse JSON numbers', function (cb) {
         socket._handleData(socket._formatMessageData('12.34'));
-        assert.equal(messages.length, 1);
-        assert.equal(messages[0], 12.34);
+        process.nextTick(function () {
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0], 12.34);
+            cb();
+        });
     });
 
-    it('should parse JSON bools', function () {
+    it('should parse JSON bools', function (cb) {
         socket._handleData(socket._formatMessageData(true));
-        assert.equal(messages.length, 1);
-        assert.equal(messages[0], true);
+        process.nextTick(function () {
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0], true);
+            cb();
+        });
     });
 
-    it('should parse JSON objects', function () {
+    it('should parse JSON objects', function (cb) {
         socket._handleData(socket._formatMessageData({"a": "yes", "b": 9}));
-        assert.equal(messages.length, 1);
-        assert.deepEqual(messages[0], {a: 'yes', b: 9});
+        process.nextTick(function () {
+            assert.equal(messages.length, 1);
+            assert.deepEqual(messages[0], {a: 'yes', b: 9});
+            cb();
+        });
     });
 
-    it('should parse JSON arrays', function () {
+    it('should parse JSON arrays', function (cb) {
         socket._handleData(socket._formatMessageData(["yes", 9]));
-        assert.equal(messages.length, 1);
-        assert.deepEqual(messages[0], ['yes', 9]);
+        process.nextTick(function () {
+            assert.equal(messages.length, 1);
+            assert.deepEqual(messages[0], ['yes', 9]);
+            cb();
+        });
     });
 
-    it('should parse multiple messages in one packet', function () {
+    it('should parse multiple messages in one packet', function (cb) {
         socket._handleData(Buffer.concat([socket._formatMessageData("hey"), socket._formatMessageData(true)]));
-        assert.equal(messages.length, 2);
-        assert.equal(messages[0], 'hey');
-        assert.equal(messages[1], true);
+        process.nextTick(function () {
+            assert.equal(messages.length, 2);
+            assert.equal(messages[0], 'hey');
+            assert.equal(messages[1], true);
+            cb();
+        });
     });
 
-    it('should parse chunked messages', function () {
+    it('should parse chunked messages', function (cb) {
         var msgSize = Buffer.byteLength('"Hello there"');
         var b = new Buffer(4 + Buffer.byteLength('"Hell'));
         b.writeUInt32LE(msgSize);
@@ -60,11 +78,14 @@ describe('JsonSocket message parsing', function () {
 
         socket._handleData(b);
         socket._handleData(c);
-        assert.equal(messages.length, 1);
-        assert.equal(messages[0], 'Hello there');
+        process.nextTick(function () {
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0], 'Hello there');
+            cb();
+        });
     });
 
-    it('should parse chunked and multiple messages', function () {
+    it('should parse chunked and multiple messages', function (cb) {
         var msgSize = Buffer.byteLength('"Hello there"');
         var b = new Buffer(4 + Buffer.byteLength('"Hell'));
         b.writeUInt32LE(msgSize);
@@ -75,12 +96,15 @@ describe('JsonSocket message parsing', function () {
         socket._handleData(b);
         //console.log('par', Buffer.concat([c, socket._formatMessageData(true)]).toString());
         socket._handleData(Buffer.concat([c, socket._formatMessageData(true)]));
-        assert.equal(messages.length, 2);
-        assert.equal(messages[0], 'Hello there');
-        assert.equal(messages[1], true);
+        process.nextTick(function () {
+            assert.equal(messages.length, 2);
+            assert.equal(messages[0], 'Hello there');
+            assert.equal(messages[1], true);
+            cb();
+        });
     });
 
-    it('should fail to parse invalid JSON', function () {
+    it('should fail to parse invalid JSON', function (cb) {
         var msgSize = Buffer.byteLength('"Hel');
         var b = new Buffer(4 + msgSize);
         b.writeUInt32LE(msgSize);
@@ -88,9 +112,14 @@ describe('JsonSocket message parsing', function () {
         try {
             socket._handleData(b);
         } catch (err) {
-            assert.equal(err.code, 'E_INVALID_JSON');
+            process.nextTick(function () {
+                assert.equal(err.code, 'E_INVALID_JSON');
+            });
         }
-        assert.equal(messages.length, 0);
+        process.nextTick(function () {
+            assert.equal(messages.length, 0);
+            cb();
+        });
     });
 
     //it('should not accept invalid content length', function () {


### PR DESCRIPTION
I made some changes to your library in order to be able to buffer data before sending them and therefore allow multiple packets to be grouped in one which removes some congestion when doing a lot of small requests.

So all strings have been replaced by Buffers and a global buffer of 65535bytes is allocated in the beginning (concats are faster on buffer than strings).

Tell me what you think of it :)
