### PR TITLE
Handle chunked multibyte characters

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -1,4 +1,6 @@
 var net = require('net');
+var StringDecoder = require('string_decoder').StringDecoder;
+var decoder = new StringDecoder();
 
 var JsonSocket = function(socket) {
     this._socket = socket;
@@ -50,7 +52,7 @@ JsonSocket.sendSingleMessageAndReceive = function(port, host, message, callback)
 JsonSocket.prototype = {
 
     _onData: function(data) {
-        data = data.toString();
+        data = decoder.write(data);
         try {
             this._handleData(data);
         } catch (e) {

--- a/test/message-parsing.test.js
+++ b/test/message-parsing.test.js
@@ -76,6 +76,14 @@ describe('JsonSocket message parsing', function() {
         assert.equal(socket._buffer, '');
     });
 
+    it('should parse chunked messages with multi-byte characters', function() {
+        // 0x33 0x23 0xd8 0x22 0xa9 0x22 = 3#"ة" (U+00629)
+        socket._onData(new Buffer([0x33, 0x23, 0x22, 0xd8]));
+        socket._onData(new Buffer([0xa9, 0x22]));
+        assert.equal(messages.length, 1);
+        assert.equal(messages[0], 'ة');
+    });
+
     it('should fail to parse invalid JSON', function() {
         try {
             socket._handleData('4#"Hel');


### PR DESCRIPTION
In some large messages (in my case, roughly 8MB strings with very large JSON objects) I was running into `JSON.parse` failures on the server side.

Before this fix, if the split between different chunks in a message occurred in the middle of a two-byte string, the first byte would still be parsed by `data.toString()` and converted into a � character. Then the second byte in the next chunk would also be converted into a � character. This would then throw the length of the string off increasing it by 1, and since this library uses the content length prefix at the beginning of the string, it would effectively ignore the last character, which is often a `}` or `]`. So `JSON.parse` would fail because of the missing closing bracket.

Node's built-in [StringDecoder](https://nodejs.org/api/string_decoder.html) module is made specifically to ensure decoded strings don't contain incomplete multibyte characters. When it tries to decode a buffer that has an incomplete character, it'll set that last byte or two aside and hold on to them until the next time it's called. 

I believe this will address the concerns in #11.
