### PR TITLE
Add in delegates from net.Socket and EventEmitter.

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -180,6 +180,7 @@ var delegates = [
     'connect',
     'on',
     'once',
+    'destroy',
     'end',
     'setTimeout',
     'setKeepAlive'

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -179,6 +179,7 @@ JsonSocket.prototype = {
 var delegates = [
     'connect',
     'on',
+    'once',
     'end',
     'setTimeout',
     'setKeepAlive'


### PR DESCRIPTION
This exposes two useful functions to have in the `JsonSocket` class:
- `destroy` from `net.Socket`
- `once` from `EventEmitter`