### PR TITLE
Bug fix for international character support

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -99,7 +99,7 @@ JsonSocket.prototype = {
             }
         }
         if (this._contentLength != null) {
-            var length = Buffer.byteLength(this._buffer, 'utf8');
+            var length = this._buffer.length;
             if (length == this._contentLength) {
                 this._handleMessage(this._buffer);
             } else if (length > this._contentLength) {
@@ -156,7 +156,7 @@ JsonSocket.prototype = {
     },
     _formatMessageData: function(message) {
         var messageData = JSON.stringify(message);
-        var length = Buffer.byteLength(messageData, 'utf8');
+        var length = messageData.length;
         var data = length + this._opts.delimeter + messageData;
         return data;
     },

--- a/test/message-parsing.test.js
+++ b/test/message-parsing.test.js
@@ -104,12 +104,12 @@ describe('JsonSocket message parsing', function() {
         assert.equal(socket._buffer, '');
     });
 
-    it('should format message with byte length', function () {
+    it('should format message with string length', function () {
         var message = socket._formatMessageData("Please take out the søppel");
         var i = message.indexOf('#');
         var rawContentLength = message.substring(0, i);
         var contentLength = parseInt(rawContentLength);
-        assert.equal(contentLength, 29);
+        assert.equal(contentLength, 28);
         socket._handleData(message);
         assert.equal(messages[0], 'Please take out the søppel');
         assert.equal(socket._buffer, '');
@@ -236,12 +236,12 @@ describe('JsonSocket message parsing with custom delimeter', function() {
         assert.equal(socket._buffer, '');
     });
 
-    it('should format message with byte length', function () {
+    it('should format message with string length', function () {
         var message = socket._formatMessageData("Please take out the søppel");
         var i = message.indexOf(socket._opts.delimeter);
         var rawContentLength = message.substring(0, i);
         var contentLength = parseInt(rawContentLength);
-        assert.equal(contentLength, 29);
+        assert.equal(contentLength, 28);
         socket._handleData(message);
         assert.equal(messages[0], 'Please take out the søppel');
         assert.equal(socket._buffer, '');

--- a/test/message-parsing.test.js
+++ b/test/message-parsing.test.js
@@ -104,6 +104,27 @@ describe('JsonSocket message parsing', function() {
         assert.equal(socket._buffer, '');
     });
 
+    it('should format message with byte length', function () {
+        var message = socket._formatMessageData("Please take out the søppel");
+        var i = message.indexOf('#');
+        var rawContentLength = message.substring(0, i);
+        var contentLength = parseInt(rawContentLength);
+        assert.equal(contentLength, 29);
+        socket._handleData(message);
+        assert.equal(messages[0], 'Please take out the søppel');
+        assert.equal(socket._buffer, '');
+    });
+
+    it('should parse multiple messages (with IC) in one packet', function () {
+        var message = socket._formatMessageData("søppel");
+        message += socket._formatMessageData("rubbish");
+        socket._handleData(message);
+        assert.equal(messages.length, 2);
+        assert.equal(messages[0], 'søppel');
+        assert.equal(messages[1], 'rubbish');
+        assert.equal(socket._buffer, '');
+    });
+
 });
 
 describe('JsonSocket message parsing with custom delimeter', function() {
@@ -212,6 +233,27 @@ describe('JsonSocket message parsing with custom delimeter', function() {
             assert.equal(err.code, 'E_INVALID_CONTENT_LENGTH');
         }
         assert.equal(messages.length, 0);
+        assert.equal(socket._buffer, '');
+    });
+
+    it('should format message with byte length', function () {
+        var message = socket._formatMessageData("Please take out the søppel");
+        var i = message.indexOf(socket._opts.delimeter);
+        var rawContentLength = message.substring(0, i);
+        var contentLength = parseInt(rawContentLength);
+        assert.equal(contentLength, 29);
+        socket._handleData(message);
+        assert.equal(messages[0], 'Please take out the søppel');
+        assert.equal(socket._buffer, '');
+    });
+
+    it('should parse multiple messages (with IC) in one packet', function () {
+        var message = socket._formatMessageData("søppel");
+        message += socket._formatMessageData("rubbish");
+        socket._handleData(message);
+        assert.equal(messages.length, 2);
+        assert.equal(messages[0], 'søppel');
+        assert.equal(messages[1], 'rubbish');
         assert.equal(socket._buffer, '');
     });
 


### PR DESCRIPTION
I ran into an issue with this library when parsing multiple messages with international characters. Since the messages are encoded using Buffer.byteLength, the substring in handleData fails (since byteLength will be greater than the actual substring length):
https://github.com/sebastianseilund/node-json-socket/blob/master/lib/json-socket.js#L106

I am pushing 3 commits to demonstrate the issue and support the bug fix proposal.

Please let me know if you have any questions or concerns! :beers: 