### PR TITLE
handling the exception that may occur when writing on socket

### DIFF
--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -136,7 +136,7 @@ JsonSocket.prototype = {
     },
 
     sendMessage: function(message, callback) {
-        if (this._closed) {
+        if (this._closed || !this._socket.writable) {
             if (callback) {
                 callback(new Error('The socket is closed.'));
             }


### PR DESCRIPTION
Hi Sir,

i faced an error when writing on socket with multi users.

i had checked out below you used
'https://github.com/nodejs/node/blob/master/lib/net.js'

it calls 'emit('close', ...) after already closed, so assumed your '_closed' value might be not synchronized.

Thank you
Rolancia